### PR TITLE
Fix #1: Correct subtraction operator inverted result

### DIFF
--- a/TP3---LOG3000-main/operators.py
+++ b/TP3---LOG3000-main/operators.py
@@ -17,16 +17,16 @@ def add(a, b):
 
 
 def subtract(a, b):
-    """Subtract the left operand from the right.
+    """Subtract the right operand from the left.
 
     Args:
         a (float): Left operand.
         b (float): Right operand.
 
     Returns:
-        float: Result of b - a.
+        float: Result of a - b.
     """
-    return b - a
+    return a - b
 
 
 def multiply(a, b):
@@ -40,7 +40,6 @@ def multiply(a, b):
         float: Result of a ** b.
     """
     return a ** b
-
 
 def divide(a, b):
     """Divide the left operand by the right using integer division.


### PR DESCRIPTION
## Description
Fixes #1 

Changed the `subtract()` function in `operators.py` to return `a - b` instead of `b - a`, correcting the inverted result bug.

## Tests
The following tests now pass:
- `tests/test_calculate.py::test_calculate_subtraction`
- `tests/test_operators.py::test_subtract`

## Changes
- Modified `operators.py`: corrected subtract function logic