### PR TITLE
Fix #2: Change multiply() to use multiplication operator

### DIFF
--- a/TP3---LOG3000-main/operators.py
+++ b/TP3---LOG3000-main/operators.py
@@ -37,9 +37,9 @@ def multiply(a, b):
         b (float): Right operand.
 
     Returns:
-        float: Result of a ** b.
+        float: Result of a * b.
     """
-    return a ** b
+    return a * b
 
 
 def divide(a, b):


### PR DESCRIPTION
## Description
Fixes #2

Changed the `multiply()` function to use the multiplication operator (*) instead of the exponentiation operator (**), fixing the bug where 6*7 returned 279936 instead of 42.

## Tests
The following tests now pass:
- `tests/test_calculate.py::test_calculate_multiplication`
- `tests/test_operators.py::test_multiply`

## Changes
- Modified `operators.py`: corrected multiply function to use * operator