### PR TITLE
Fix #3: Correct calculator button labels

### DIFF
--- a/TP3---LOG3000-main/templates/index.html
+++ b/TP3---LOG3000-main/templates/index.html
@@ -14,7 +14,7 @@
 
       <div class="buttons">
          <button type="button" class="btn" onclick="appendToDisplay('1')">1</button>
-         <button type="button" class="btn" onclick="appendToDisplay('2')">02</button>
+         <button type="button" class="btn" onclick="appendToDisplay('2')">2</button>
          <button type="button" class="btn" onclick="appendToDisplay('3')">3</button>
          <button type="button" class="btn operator" onclick="appendToDisplay('+')">+</button>
 
@@ -24,14 +24,14 @@
          <button type="button" class="btn operator" onclick="appendToDisplay('-')">-</button>
 
          <button type="button" class="btn" onclick="appendToDisplay('7')">7</button>
-         <button type="button" class="btn" onclick="appendToDisplay('8')">88</button>
+         <button type="button" class="btn" onclick="appendToDisplay('8')">8</button>
          <button type="button" class="btn" onclick="appendToDisplay('9')">9</button>
-         <button type="button" class="btn operator" onclick="appendToDisplay('*')"></button>
+         <button type="button" class="btn operator" onclick="appendToDisplay('*')">*</button>
 
          <button type="button" class="btn" onclick="appendToDisplay('0')">0</button>
          <button type="button" class="btn" onclick="clearDisplay()">C</button>
          <button type="submit" class="btn operator">=</button>
-         <button type="button" class="btn operator" onclick="appendToDisplay('/')"></button>
+         <button type="button" class="btn operator" onclick="appendToDisplay('/')">/</button>
       </div>
    </form>
 </div>


### PR DESCRIPTION
## Description
Fixes #3

Fixed incorrect button labels on the calculator UI and added missing operator labels.

## Tests
The following issues are now resolved:
- Button "2" now displays "2" (was "02")
- Button "8" now displays "8" (was "88")
- Multiplication button (*) now displays "*" (was blank)
- Division button (/) now displays "/" (was blank)

## Changes
- Modified `templates/index.html`: corrected button labels for buttons 2, 8, * and /

<img width="742" height="843" alt="image" src="https://github.com/user-attachments/assets/75f3ec2d-0f03-46d5-b630-5e80f8036e2b" />
