### PR TITLE
Fix #4: Change divide() to use true division

### DIFF
--- a/TP3---LOG3000-main/operators.py
+++ b/TP3---LOG3000-main/operators.py
@@ -43,13 +43,13 @@ def multiply(a, b):
 
 
 def divide(a, b):
-    """Divide the left operand by the right using integer division.
+    """Divide the left operand by the right.
 
     Args:
         a (float): Left operand.
         b (float): Right operand.
 
     Returns:
-        float: Integer-division result of a // b.
+        float: Result of a / b.
     """
-    return a // b
+    return a / b


### PR DESCRIPTION
## Description
Fixes #4

Changed the `divide()` function to use true division (/) instead of floor division (//), enabling proper decimal results instead of truncating them.

## Tests
The following tests now pass:
- `tests/test_calculate.py::test_calculate_division`
- `tests/test_operators.py::test_divide`

## Changes
- Modified `operators.py`: replaced // with / in divide function